### PR TITLE
fix: address audit issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ All PRs should maintain the existing test coverage (~97%). New features should i
 ## Code Style
 
 - Python 3.11+
-- Black formatter, Ruff linter
+- Ruff linter/formatter
 - Type hints encouraged
 - Docstrings for public methods
 
@@ -41,12 +41,12 @@ Check the [issues page](https://github.com/0xbrando/dictate/issues) for open ite
 
 ```
 dictate/
-├── main.py          # Entry point, daemon management
+├── menubar_main.py  # CLI entry point, daemon management
 ├── menubar.py       # Menu bar UI (rumps)
-├── transcribe.py    # STT pipeline (Whisper + Parakeet)
-├── llm.py           # LLM text cleanup
+├── transcribe.py    # STT pipeline and LLM text cleanup
+├── presets.py       # Menu presets and preference persistence
 ├── audio.py         # Audio capture, VAD
-└── config.py        # Preferences, env vars
+└── config.py        # Runtime config and env vars
 ```
 
 ## PR Guidelines

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ Dictate auto-switches engines based on language: ANE/Parakeet for European langu
 | **Clean Up** | Fixes punctuation and capitalization — keeps your words |
 | **Professional** | Polished tone and grammar |
 | **Bullet Points** | Rewrites as concise bullet points |
+| **Email** | Formats as a concise, polished email |
+| **Slack/Chat** | Clear conversational message |
+| **Technical** | Precise technical wording |
+| **Tweet** | Short social post |
+| **Raw** | Exact transcription with no LLM rewrite |
 
 Toggle LLM cleanup off from the menu bar for raw transcription output.
 
@@ -292,7 +297,7 @@ dictate -V           # Show version
 
 | Key | Values |
 |-----|--------|
-| `writing_style` | clean, professional, bullets |
+| `writing_style` | clean, professional, bullets, email, slack, technical, tweet, raw |
 | `quality` | api, fast, balanced, quality |
 | `stt` | ane, qwen3-asr, parakeet, whisper |
 | `input_language` | auto, en, ja, de, fr, es, ... |
@@ -301,6 +306,7 @@ dictate -V           # Show version
 | `llm_cleanup` | on, off |
 | `sound` | soft_pop, chime, warm, click, marimba, simple |
 | `llm_endpoint` | host:port (for API backend) |
+| `device_id` | device number, or auto |
 
 ## Shell Completions
 

--- a/completions/dictate.bash
+++ b/completions/dictate.bash
@@ -8,15 +8,16 @@ _dictate_completions() {
 
     local commands="config stats status doctor devices update"
     local config_subcmds="show set reset path"
-    local config_keys="writing_style quality stt input_language output_language ptt_key command_key llm_cleanup sound llm_endpoint advanced_mode"
-    local writing_styles="clean formal raw"
-    local quality_values="0 1 2 3 4 api speedy fast balanced quality"
-    local stt_values="0 1 parakeet whisper"
+    local config_keys="writing_style quality stt input_language output_language ptt_key command_key llm_cleanup sound llm_endpoint advanced_mode device_id"
+    local writing_styles="clean professional bullets email slack technical tweet raw"
+    local quality_values="0 1 2 3 api fast balanced quality"
+    local stt_values="0 1 2 3 ane qwen3-asr parakeet whisper"
     local languages="auto en pl de fr es it pt nl ja zh ko ru"
     local ptt_keys="ctrl_l ctrl_r cmd_r alt_l alt_r"
     local command_keys="none alt_r alt_l cmd_r ctrl_r"
-    local bool_values="on off"
+    local bool_values="on off true false 1 0"
     local sound_values="0 1 2 3 4 5 6 soft_pop chime warm click marimba simple"
+    local device_values="auto default system none"
 
     case "${cword}" in
         1)
@@ -51,6 +52,7 @@ _dictate_completions() {
                             llm_cleanup) COMPREPLY=( $(compgen -W "${bool_values}" -- "${cur}") ) ;;
                             sound) COMPREPLY=( $(compgen -W "${sound_values}" -- "${cur}") ) ;;
                             advanced_mode) COMPREPLY=( $(compgen -W "${bool_values}" -- "${cur}") ) ;;
+                            device_id) COMPREPLY=( $(compgen -W "${device_values}" -- "${cur}") ) ;;
                         esac
                         return
                     fi

--- a/completions/dictate.zsh
+++ b/completions/dictate.zsh
@@ -6,28 +6,35 @@
 
 _dictate_writing_styles=(
     'clean:Fixes punctuation, keeps your words'
-    'formal:Professional tone and grammar'
+    'professional:Professional tone and grammar'
+    'bullets:Concise bullet points'
+    'email:Polished email'
+    'slack:Concise chat message'
+    'technical:Precise technical wording'
+    'tweet:Short social post'
     'raw:Exact transcription, no LLM processing'
 )
 
 _dictate_quality_values=(
-    'api:External API backend'
-    'speedy:1.5B model (fastest)'
-    'fast:3B model'
-    'balanced:4B model'
-    'quality:8B model (best quality)'
+    'api:Local API backend'
+    'fast:1.5B model'
+    'balanced:2B model'
+    'quality:3B model'
     '0:API backend'
-    '1:1.5B model'
-    '2:3B model'
-    '3:4B model'
-    '4:8B model'
+    '1:Fast 1.5B model'
+    '2:Balanced 2B model'
+    '3:Quality 3B model'
 )
 
 _dictate_stt_values=(
-    'parakeet:Parakeet MLX (English, fastest)'
-    'whisper:Whisper MLX (multilingual)'
-    '0:Parakeet'
-    '1:Whisper'
+    'ane:Apple Neural Engine'
+    'qwen3-asr:Qwen3-ASR'
+    'parakeet:Parakeet MLX'
+    'whisper:Whisper MLX'
+    '0:ANE'
+    '1:Qwen3-ASR'
+    '2:Parakeet'
+    '3:Whisper'
 )
 
 _dictate_languages=(
@@ -85,6 +92,7 @@ _dictate_config_set_value() {
         sound) _describe 'sound preset' _dictate_sound_values ;;
         llm_endpoint) _message 'host:port (e.g., localhost:11434)' ;;
         advanced_mode) _values 'toggle' on off ;;
+        device_id) _values 'input device' auto default system none ;;
     esac
 }
 
@@ -100,6 +108,7 @@ _dictate_config_keys=(
     'sound:Sound feedback preset'
     'llm_endpoint:LLM API endpoint (host\:port)'
     'advanced_mode:Enable advanced mode in menu bar'
+    'device_id:Audio input device id'
 )
 
 _dictate() {

--- a/dictate/config.py
+++ b/dictate/config.py
@@ -265,6 +265,33 @@ class LLMConfig:
                 "Each bullet should capture one key idea. "
                 "Output ONLY the bullet points, one per line, starting with '- '."
             ),
+            "email": (
+                "You are a dictation post-processor. "
+                "Rewrite the input as a concise, polished email. "
+                "Preserve the user's intent and do not invent facts. "
+                "Output ONLY the email text."
+            ),
+            "slack": (
+                "You are a dictation post-processor. "
+                "Rewrite the input as a clear, conversational chat message. "
+                "Keep it concise and natural. "
+                "Output ONLY the message."
+            ),
+            "technical": (
+                "You are a dictation post-processor. "
+                "Rewrite the input with precise technical wording, preserving code terms, product names, and exact details. "
+                "Output ONLY the rewritten text."
+            ),
+            "tweet": (
+                "You are a dictation post-processor. "
+                "Rewrite the input as a short social post under 280 characters when possible. "
+                "Do not add hashtags unless the user dictated them. "
+                "Output ONLY the post."
+            ),
+            "raw": (
+                "You are a dictation post-processor. "
+                "Output ONLY the input text exactly unchanged."
+            ),
         }
 
         style = style_prompts.get(self.writing_style, style_prompts["clean"])

--- a/dictate/menubar_main.py
+++ b/dictate/menubar_main.py
@@ -550,10 +550,10 @@ def _run_doctor() -> int:
     from dictate.presets import Preferences, PREFS_FILE
     if PREFS_FILE.exists():
         prefs = Preferences.load()
-        if prefs.llm_endpoint and prefs.llm_endpoint != "localhost:8080":
+        if prefs.is_api_backend:
             import urllib.request
             import urllib.error
-            url = f"http://{prefs.llm_endpoint}/v1/models"
+            url = prefs.validated_api_url.replace("/chat/completions", "/models")
             try:
                 req = urllib.request.urlopen(url, timeout=3)
                 req.close()

--- a/dictate/presets.py
+++ b/dictate/presets.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from dictate.config import LLMBackend, LLMModel, STTEngine
-from dictate.llm_discovery import discover_llm, get_display_name
+from dictate.llm_discovery import _clean_model_name, discover_llm
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +206,11 @@ WRITING_STYLES: list[tuple[str, str, str]] = [
     ("clean", "Clean Up", "Fixes punctuation, keeps your words"),
     ("professional", "Professional", "Polished tone and grammar"),
     ("bullets", "Bullet Points", "Rewrites as concise bullet points"),
+    ("email", "Email", "Formats as a polished email"),
+    ("slack", "Slack/Chat", "Concise, conversational message"),
+    ("technical", "Technical", "Precise technical wording"),
+    ("tweet", "Tweet", "Short social post"),
+    ("raw", "Raw", "No LLM rewrite"),
 ]
 
 
@@ -340,6 +345,10 @@ class Preferences:
     def _refresh_discovery(self) -> None:
         """Refresh the discovered model name from the endpoint."""
         if self.backend == LLMBackend.API:
+            url = self._endpoint_to_api_url(self.llm_endpoint)
+            if not self._is_safe_api_url(url) and os.environ.get("DICTATE_ALLOW_REMOTE_API") != "1":
+                self._discovered_model = None
+                return
             result = discover_llm(self.llm_endpoint)
             if result.is_available:
                 self._discovered_model = result.name
@@ -377,7 +386,9 @@ class Preferences:
         """
         if self.backend != LLMBackend.API:
             return ""
-        return get_display_name(self.llm_endpoint)
+        if not self._discovered_model:
+            return "No local model found"
+        return _clean_model_name(self._discovered_model)
 
     @property
     def stt_engine(self) -> STTEngine:
@@ -414,6 +425,31 @@ class Preferences:
         except Exception:
             return False
 
+    @staticmethod
+    def _endpoint_to_api_url(endpoint: str) -> str:
+        """Normalize a user endpoint into an OpenAI-compatible chat URL."""
+        fallback = "http://localhost:8005/v1/chat/completions"
+        endpoint = endpoint.strip()
+        if not endpoint:
+            return fallback
+
+        if "://" in endpoint:
+            parsed = urlparse(endpoint)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                return fallback
+            scheme = parsed.scheme
+            netloc = parsed.netloc
+        else:
+            endpoint = endpoint.split("/")[0]
+            parsed = urlparse(f"//{endpoint}")
+            if not parsed.netloc:
+                return fallback
+            host = parsed.hostname or ""
+            scheme = "http" if host in ("localhost", "127.0.0.1", "::1", "0.0.0.0") else "https"
+            netloc = parsed.netloc
+
+        return f"{scheme}://{netloc}/v1/chat/completions"
+
     @property
     def validated_api_url(self) -> str:
         """Get the API URL to use.
@@ -421,26 +457,17 @@ class Preferences:
         For API backend, uses the endpoint. For local, uses the legacy api_url.
         """
         if self.backend == LLMBackend.API:
-            # Use endpoint-based URL
-            endpoint = self.llm_endpoint.strip()
-            # Remove protocol prefix if present
-            if endpoint.startswith("http://"):
-                endpoint = endpoint[7:]
-            elif endpoint.startswith("https://"):
-                endpoint = endpoint[8:]
-            # Remove trailing slash and path
-            endpoint = endpoint.split("/")[0]
-            url = f"http://{endpoint}/v1/chat/completions"
+            url = self._endpoint_to_api_url(self.llm_endpoint)
             # Apply same localhost safety check as legacy path
             if not self._is_safe_api_url(url):
                 if os.environ.get("DICTATE_ALLOW_REMOTE_API") == "1":
                     logger.warning(
-                        "Remote API endpoint allowed via DICTATE_ALLOW_REMOTE_API: %s", endpoint
+                        "Remote API endpoint allowed via DICTATE_ALLOW_REMOTE_API: %s", url
                     )
                 else:
                     logger.warning(
                         "Blocked non-localhost endpoint: %s (set DICTATE_ALLOW_REMOTE_API=1 to override)",
-                        endpoint,
+                        url,
                     )
                     return "http://localhost:8005/v1/chat/completions"
             return url

--- a/dictate/transcribe.py
+++ b/dictate/transcribe.py
@@ -555,6 +555,7 @@ class TextCleaner:
         self._model = None
         self._tokenizer = None
         self._last_cleanup_failed = False
+        self._generation_lock = threading.Lock()
 
     def load_model(self) -> None:
         if self._model is not None:
@@ -580,6 +581,11 @@ class TextCleaner:
         if self._model is None or self._tokenizer is None:
             self.load_model()
 
+        if not self._generation_lock.acquire(blocking=False):
+            logger.warning("Local LLM cleanup already in progress, returning raw text")
+            self._last_cleanup_failed = True
+            return text
+
         from mlx_lm import generate
         from mlx_lm.sample_utils import make_sampler
 
@@ -603,21 +609,36 @@ class TextCleaner:
         sampler = make_sampler(temp=self._config.temperature)
 
         result_box: list[str] = []
+        error_box: list[BaseException] = []
 
         def _run_generate() -> None:
-            result_box.append(
-                generate(
-                    self._model,
-                    self._tokenizer,
-                    prompt=prompt,
-                    max_tokens=max_tokens,
-                    sampler=sampler,
+            try:
+                result_box.append(
+                    generate(
+                        self._model,
+                        self._tokenizer,
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        sampler=sampler,
+                    )
                 )
-            )
+            except BaseException as e:
+                error_box.append(e)
+            finally:
+                self._generation_lock.release()
 
         thread = threading.Thread(target=_run_generate, daemon=True)
         thread.start()
         thread.join(timeout=LOCAL_LLM_TIMEOUT_SECONDS)
+
+        if error_box:
+            error = error_box[0]
+            logger.error(
+                "Local LLM cleanup failed, returning raw text",
+                exc_info=(type(error), error, error.__traceback__),
+            )
+            self._last_cleanup_failed = True
+            return text
 
         if not result_box:
             logger.warning(
@@ -628,6 +649,7 @@ class TextCleaner:
 
         result = result_box[0]
         logger.debug("LLM raw result: %r", result[:100] if len(result) > 100 else result)
+        self._last_cleanup_failed = False
         return _postprocess(result.strip())
 
 
@@ -970,8 +992,14 @@ class TranscriptionPipeline:
                 return None
             return raw_text
 
+        if self._llm_config.enabled and self._llm_config.writing_style == "raw":
+            logger.info("Skipped LLM (raw writing style)")
+            if self._is_duplicate(raw_text):
+                return None
+            return raw_text
+
         cleaner = self._pick_cleaner(word_count)
-        route = "local" if cleaner is self._fast_cleaner else "API"
+        route = "API" if isinstance(cleaner, APITextCleaner) else "local"
 
         t2 = time.time()
         cleaned_text = cleaner.cleanup(raw_text, output_language=output_language).strip()

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -41,12 +41,12 @@ class TestBashCompletions:
 
     def test_bash_completion_has_writing_styles(self):
         content = (COMPLETIONS_DIR / "dictate.bash").read_text()
-        for style in ["clean", "formal", "raw"]:
+        for style in ["clean", "professional", "bullets", "email", "slack", "technical", "tweet", "raw"]:
             assert style in content, f"Missing writing style: {style}"
 
     def test_bash_completion_has_quality_aliases(self):
         content = (COMPLETIONS_DIR / "dictate.bash").read_text()
-        for alias in ["api", "speedy", "fast", "balanced", "quality"]:
+        for alias in ["api", "fast", "balanced", "quality"]:
             assert alias in content, f"Missing quality alias: {alias}"
 
     def test_bash_completion_has_languages(self):
@@ -126,7 +126,7 @@ class TestZshCompletions:
 
     def test_zsh_completion_has_writing_styles(self):
         content = (COMPLETIONS_DIR / "dictate.zsh").read_text()
-        for style in ["clean", "formal", "raw"]:
+        for style in ["clean", "professional", "bullets", "email", "slack", "technical", "tweet", "raw"]:
             assert style in content, f"Missing writing style: {style}"
 
     def test_zsh_completion_has_config_keys(self):
@@ -148,9 +148,9 @@ class TestZshCompletions:
 
     def test_zsh_completion_has_quality_descriptions(self):
         content = (COMPLETIONS_DIR / "dictate.zsh").read_text()
-        assert "1.5B" in content  # speedy
-        assert "3B" in content  # fast
-        assert "8B" in content  # quality
+        assert "1.5B" in content  # fast
+        assert "2B" in content  # balanced
+        assert "3B" in content  # quality
 
     def test_zsh_completion_has_language_descriptions(self):
         content = (COMPLETIONS_DIR / "dictate.zsh").read_text()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -127,6 +127,18 @@ class TestLLMConfig:
         prompt = c.get_system_prompt()
         assert "professional" in prompt.lower()
 
+    def test_system_prompt_additional_styles(self):
+        for style, expected in {
+            "email": "email",
+            "slack": "chat message",
+            "technical": "technical",
+            "tweet": "social post",
+            "raw": "unchanged",
+        }.items():
+            c = LLMConfig(writing_style=style)
+            prompt = c.get_system_prompt()
+            assert expected in prompt.lower()
+
     def test_system_prompt_translation(self):
         c = LLMConfig(writing_style="clean")
         prompt = c.get_system_prompt(output_language="es")

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -77,6 +77,10 @@ class TestPresetData:
         keys = [k for k, _, _ in WRITING_STYLES]
         assert "bullets" in keys
 
+    def test_writing_styles_match_cli_claims(self):
+        keys = {k for k, _, _ in WRITING_STYLES}
+        assert {"clean", "professional", "bullets", "email", "slack", "technical", "tweet", "raw"} <= keys
+
 
 # ── Hardware detection ─────────────────────────────────────────
 

--- a/tests/test_presets_coverage.py
+++ b/tests/test_presets_coverage.py
@@ -170,6 +170,21 @@ class TestRefreshDiscovery:
         prefs._refresh_discovery()
         assert prefs._discovered_model is None
 
+    def test_refresh_discovery_remote_blocked_without_opt_in(self, monkeypatch):
+        """Remote endpoint discovery should follow the remote API opt-in policy."""
+        import dictate.presets as presets
+
+        monkeypatch.delenv("DICTATE_ALLOW_REMOTE_API", raising=False)
+        prefs = presets.Preferences(quality_preset=0, llm_endpoint="example.com:11434")
+        monkeypatch.setattr(
+            presets,
+            "discover_llm",
+            lambda endpoint: pytest.fail("remote endpoint should not be probed"),
+        )
+
+        prefs._refresh_discovery()
+        assert prefs._discovered_model is None
+
 
 class TestUpdateEndpoint:
     """Cover update_endpoint() method (lines 282-283)."""
@@ -213,14 +228,24 @@ class TestDiscoveredModelDisplay:
     """Cover discovered_model_display property (lines 307-309)."""
 
     def test_discovered_model_display_api_backend(self, monkeypatch):
-        """Lines 307-309: Returns display name when backend is API."""
+        """Returns the cached display name when backend is API."""
         import dictate.presets as presets
 
         prefs = presets.Preferences(quality_preset=0, llm_endpoint="localhost:11434")
-        monkeypatch.setattr(presets, "get_display_name", lambda endpoint: "qwen3-coder via localhost:11434")
+        prefs._discovered_model = "qwen3-coder:30b"
+        monkeypatch.setattr(presets, "_clean_model_name", lambda name: "Qwen3 Coder")
 
         result = prefs.discovered_model_display
-        assert result == "qwen3-coder via localhost:11434"
+        assert result == "Qwen3 Coder"
+
+    def test_discovered_model_display_api_backend_no_model(self):
+        """Unavailable API backend returns a stable label without probing the network."""
+        import dictate.presets as presets
+
+        prefs = presets.Preferences(quality_preset=0, llm_endpoint="localhost:11434")
+        prefs._discovered_model = None
+
+        assert prefs.discovered_model_display == "No local model found"
 
     def test_discovered_model_display_non_api(self):
         """Returns empty string for non-API backend."""
@@ -316,12 +341,12 @@ class TestValidatedApiUrl:
         assert result == "http://localhost:11434/v1/chat/completions"
 
     def test_validated_api_url_protocol_stripping_https(self, monkeypatch):
-        """Strip https:// prefix from endpoint."""
+        """Preserve explicit https:// endpoints."""
         import dictate.presets as presets
 
         prefs = presets.Preferences(quality_preset=0, llm_endpoint="https://localhost:11434")
         result = prefs.validated_api_url
-        assert result == "http://localhost:11434/v1/chat/completions"
+        assert result == "https://localhost:11434/v1/chat/completions"
 
     def test_validated_api_url_remote_blocked(self, monkeypatch):
         """Remote endpoint blocked without env var."""
@@ -342,6 +367,16 @@ class TestValidatedApiUrl:
         monkeypatch.setenv("DICTATE_ALLOW_REMOTE_API", "1")
 
         prefs = presets.Preferences(quality_preset=0, llm_endpoint="example.com:11434")
+        result = prefs.validated_api_url
+        assert result == "https://example.com:11434/v1/chat/completions"
+
+    def test_validated_api_url_remote_explicit_http_allowed_via_env(self, monkeypatch):
+        """Explicit remote http is only preserved after the remote opt-in."""
+        import dictate.presets as presets
+
+        monkeypatch.setenv("DICTATE_ALLOW_REMOTE_API", "1")
+
+        prefs = presets.Preferences(quality_preset=0, llm_endpoint="http://example.com:11434")
         result = prefs.validated_api_url
         assert result == "http://example.com:11434/v1/chat/completions"
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from dictate.transcribe import _dedup_transcription, _looks_clean, _postprocess
+from dictate.config import LLMConfig
+from dictate.transcribe import TextCleaner, _dedup_transcription, _looks_clean, _postprocess
 
 
 # ── _postprocess ──────────────────────────────────────────────
@@ -147,3 +148,16 @@ class TestDedupTranscription:
 
     def test_empty_string(self):
         assert _dedup_transcription("") == ""
+
+
+class TestTextCleaner:
+    def test_cleanup_returns_raw_when_generation_busy(self):
+        cleaner = TextCleaner(LLMConfig())
+        cleaner._model = object()
+        cleaner._tokenizer = object()
+        cleaner._generation_lock.acquire()
+        try:
+            assert cleaner.cleanup("hello world") == "hello world"
+            assert cleaner._last_cleanup_failed is True
+        finally:
+            cleaner._generation_lock.release()

--- a/tests/test_writing_styles.py
+++ b/tests/test_writing_styles.py
@@ -35,9 +35,19 @@ class TestWritingStyles:
         assert "professional" in keys
         assert "bullets" in keys
 
-    def test_has_3_styles(self):
-        """We have exactly 3 writing styles (simplified)."""
-        assert len(WRITING_STYLES) == 3
+    def test_has_expected_styles(self):
+        """WRITING_STYLES covers all CLI-advertised styles."""
+        keys = [k for k, _, _ in WRITING_STYLES]
+        assert keys == [
+            "clean",
+            "professional",
+            "bullets",
+            "email",
+            "slack",
+            "technical",
+            "tweet",
+            "raw",
+        ]
 
 
 class TestSystemPrompts:


### PR DESCRIPTION
## Summary

Addresses the codex audit for `dictate`. Adds new writing styles, hardens the LLM API URL handling, adds a generation lock to the local cleaner, and syncs completions/docs/tests with the actual quality and STT presets.

### Changes
- **New writing styles**: `email`, `slack`, `technical`, `tweet`, `raw` (with matching system prompts in `config.py` and menu presets in `presets.py`).
- **API URL hardening** (`presets.py`): normalize endpoints via `_endpoint_to_api_url`, localhost-only unless `DICTATE_ALLOW_REMOTE_API=1`, preserve explicit `https://`, and gate discovery behind the same policy.
- **Generation lock** (`transcribe.py`): `TextCleaner` now guards concurrent generation with a non-blocking lock and surfaces generation errors (returns raw text instead of hanging/crashing).
- **Completions/docs**: `dictate.bash` / `dictate.zsh`, `README.md`, `CONTRIBUTING.md` updated to the real presets — quality `api/fast/balanced/quality` (1.5B/2B/3B), STT `ane/qwen3-asr/parakeet/whisper`, plus `device_id`.

### Notes for reviewers
- The source patch shipped with headerless `@@` hunks that `git apply` could not parse; it was applied by context-matching each hunk (each verified to match exactly once).
- **Two fixes beyond the raw patch:**
  1. `transcribe.py` route label: `isinstance(cleaner, TextCleaner)` raised `TypeError` when a test mocks `TextCleaner` → switched to an `APITextCleaner` check (mock-safe and more correct — only the API cleaner is the "API" route).
  2. Updated stale contract tests (`test_has_3_styles`, completion style/quality assertions) that still encoded the old `formal`/`speedy`/`8B` presets. Verified the new values against the real `menubar_main.py` / `config.py` definitions.

### Verification
- Full suite: **1067 passed**.
- All changed modules byte-compile clean. No ruff/CI configured in-repo; the test suite is the gate.