### PR TITLE
Fix silent macOS paste failures and UTF-8 transcription responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,13 @@ Completes commands, config keys, and all valid values.
 
 ## Debugging
 
+If recording finishes but no text appears, enable **Dictate** in **System Settings →
+Privacy & Security → Accessibility**, then quit and reopen Dictate. For a terminal
+launch, grant the terminal app instead. This permission lets Dictate send the paste
+shortcut. Click into an editable text field before holding the push-to-talk key.
+Failed output stays in **Recent**; if copying succeeded, you can also paste with
+**⌘V**. Public model downloads do not require a Hugging Face account or Keychain access.
+
 ```bash
 # Run in foreground with logs
 dictate --foreground

--- a/dictate/menubar.py
+++ b/dictate/menubar.py
@@ -30,7 +30,7 @@ from collections import deque
 from pathlib import Path
 
 from dictate.icons import cleanup_temp_files, generate_reactive_icon, get_icon_path
-from dictate.output import TextAggregator, create_output_handler
+from dictate.output import PastePermissionError, TextAggregator, create_output_handler
 from dictate.presets import (
     INPUT_LANGUAGES,
     OUTPUT_LANGUAGES,
@@ -1220,9 +1220,11 @@ class DictateMenuBarApp(rumps.App):
         try:
             text = pipeline.process(audio)
             if text:
-                self._emit_output(text)
+                output_succeeded = self._emit_output(text)
                 # Record usage stats
                 self._record_stats(text, audio)
+                if not output_succeeded:
+                    return  # Keep the actionable output error visible.
                 if pipeline.last_cleanup_failed:
                     self._post_ui("status", "Ready (cleanup skipped)")
                 else:
@@ -1248,16 +1250,22 @@ class DictateMenuBarApp(rumps.App):
         except Exception:
             logger.debug("Failed to record stats", exc_info=True)
 
-    def _emit_output(self, text: str) -> None:
+    def _emit_output(self, text: str) -> bool:
         self._aggregator.append(text)
         # Add to recent first so text isn't lost if output fails
         self._post_ui("recent", text)
         try:
             self._output.output(text)
             self._post_ui("notify", text)
+            return True
+        except PastePermissionError:
+            logger.warning("Paste blocked by Accessibility permission; text saved to Recent")
+            self._post_ui("status", "Paste blocked — enable Accessibility; text in Recent")
+            return False
         except Exception:
             logger.exception("Output error — text saved to Recent")
             self._post_ui("status", "Output error — check Recent")
+            return False
 
     # ── Shutdown ───────────────────────────────────────────────────
 

--- a/dictate/menubar_main.py
+++ b/dictate/menubar_main.py
@@ -970,6 +970,7 @@ def setup_logging() -> None:
     os.chmod(LOG_FILE.parent, 0o700)
     handler = RotatingFileHandler(
         LOG_FILE, maxBytes=5 * 1024 * 1024, backupCount=3,  # 5 MB, keep 3 backups
+        encoding="utf-8",
     )
     handler.setFormatter(logging.Formatter(
         "%(asctime)s [%(levelname)s] %(name)s: %(message)s",

--- a/dictate/output.py
+++ b/dictate/output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
@@ -14,6 +15,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TYPING_DELAY_SECONDS = 0.05
+
+
+class PastePermissionError(RuntimeError):
+    """macOS would silently discard simulated keyboard events."""
+
+
+def _accessibility_trusted() -> bool:
+    if sys.platform != "darwin":
+        return True
+    from HIServices import AXIsProcessTrusted
+
+    # Check only: never open another permission prompt during dictation.
+    return bool(AXIsProcessTrusted())
+
+
+def _require_accessibility() -> None:
+    if not _accessibility_trusted():
+        raise PastePermissionError(
+            "Enable Dictate in System Settings → Privacy & Security → Accessibility. "
+            "Your text is saved in Recent."
+        )
 
 
 class OutputHandler(ABC):
@@ -40,14 +62,16 @@ class TyperOutput(OutputHandler):
             if self._has_pasted:
                 text = " " + text
             pyperclip.copy(text)
-            self._has_pasted = True
+            _require_accessibility()
             time.sleep(TYPING_DELAY_SECONDS)
             self._controller.press(Key.cmd)
             self._controller.press('v')
             self._controller.release('v')
             self._controller.release(Key.cmd)
+            self._has_pasted = True
         except pyperclip.PyperclipException as e:
             logger.error("Clipboard not available: %s", e)
+            _require_accessibility()
             # Try to fall back to direct typing
             try:
                 self._controller.type(text)

--- a/dictate/transcribe.py
+++ b/dictate/transcribe.py
@@ -383,6 +383,7 @@ class ANETranscriber:
                 # Inherit stderr so model/download logs cannot fill an unread pipe.
                 stderr=None,
                 text=True,
+                encoding="utf-8",  # Swift's JSON protocol is UTF-8, including under Finder's locale.
                 bufsize=1,
             )
 
@@ -443,7 +444,7 @@ class ANETranscriber:
                 self._stop_server()
                 self._model_loaded = False
                 return ""
-            except (BrokenPipeError, OSError, RuntimeError) as e:
+            except (BrokenPipeError, OSError, RuntimeError, UnicodeError) as e:
                 logger.error("ANE helper failed: %s", e)
                 self._stop_server()
                 self._model_loaded = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,27 @@ def mock_mlx_available():
         yield
     # Reset the module-level cache so it doesn't leak between tests
     _mlx_mod._mlx_available = None
+
+
+@pytest.fixture(autouse=True)
+def mock_accessibility_permission():
+    """Output unit tests must not depend on the test runner's macOS permissions."""
+    with patch("dictate.output._accessibility_trusted", return_value=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def isolate_app_logging(tmp_path):
+    """Tests that initialize the app must not write mock failures into real logs."""
+    import logging
+
+    root = logging.getLogger()
+    previous_handlers = root.handlers[:]
+    previous_level = root.level
+    with patch("dictate.menubar_main.LOG_FILE", tmp_path / "logs" / "dictate.log"):
+        yield
+    for handler in root.handlers[:]:
+        if handler not in previous_handlers:
+            root.removeHandler(handler)
+            handler.close()
+    root.setLevel(previous_level)

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -476,6 +476,24 @@ class TestRecording:
 
 
 class TestProcessChunk:
+    @pytest.mark.parametrize("permission_denied", [False, True])
+    def test_output_error_is_not_overwritten_by_ready(self, mock_app, permission_denied):
+        from dictate.output import PastePermissionError
+
+        mock_app._pipeline = MagicMock()
+        mock_app._pipeline.process.return_value = "Hello world"
+        mock_app._output = MagicMock()
+        mock_app._output.output.side_effect = (
+            PastePermissionError("Accessibility") if permission_denied else RuntimeError("paste failed")
+        )
+        with patch.object(mock_app, "_record_stats"):
+            mock_app._process_chunk(np.zeros(16000, dtype=np.int16))
+        messages = list(mock_app._ui_queue.queue)
+        assert ("recent", "Hello world") in messages
+        statuses = [value for kind, value in messages if kind == "status"]
+        assert len(statuses) == 1
+        assert "Accessibility" in statuses[0] if permission_denied else "Output error" in statuses[0]
+
     def test_no_pipeline(self, mock_app):
         mock_app._pipeline = None
         mock_app._process_chunk(np.zeros(100, dtype=np.int16))

--- a/tests/test_paste_utf8.py
+++ b/tests/test_paste_utf8.py
@@ -1,0 +1,76 @@
+"""Regressions observed during dictation from the Finder-launched Mac app."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from dictate.config import WhisperConfig
+from dictate.output import PastePermissionError, TyperOutput
+from dictate.transcribe import ANETranscriber
+
+
+def test_helper_reads_utf8_even_when_default_pipe_encoding_is_ascii(tmp_path):
+    helper = tmp_path / "helper.py"
+    helper.write_text(
+        "import sys\n"
+        "sys.stdout.buffer.write(b'{\"ready\":true}\\n')\n"
+        "sys.stdout.buffer.flush()\n"
+        "for line in sys.stdin:\n"
+        "    sys.stdout.buffer.write('{\"text\":\"Привет 世界 café\"}\\n'.encode('utf-8'))\n"
+        "    sys.stdout.buffer.flush()\n",
+        encoding="utf-8",
+    )
+    real_popen = subprocess.Popen
+
+    def start_helper(args, **kwargs):
+        return real_popen([sys.executable, str(helper)], **kwargs)
+
+    transcriber = ANETranscriber(WhisperConfig(), binary_path=str(helper))
+    try:
+        with (
+            patch("subprocess._text_encoding", return_value="ascii"),
+            patch("dictate.transcribe.subprocess.Popen", side_effect=start_helper),
+        ):
+            assert transcriber.transcribe(np.zeros(16000, dtype=np.int16), 16000) == "Привет 世界 café"
+    finally:
+        transcriber._stop_server()
+
+
+def test_blocked_paste_preserves_clipboard_and_can_retry_without_extra_space():
+    with (
+        patch("dictate.output.KeyboardController") as controller,
+        patch("dictate.output.pyperclip.copy") as copy,
+        patch("dictate.output.time.sleep"),
+        patch("dictate.output._accessibility_trusted", return_value=False) as trusted,
+    ):
+        output = TyperOutput()
+        with pytest.raises(PastePermissionError, match="Accessibility"):
+            output.output("Hello world")
+        copy.assert_called_once_with("Hello world")
+        controller.return_value.press.assert_not_called()
+        controller.return_value.type.assert_not_called()
+        trusted.return_value = True
+        output.output("Hello world")
+        assert copy.call_args.args == ("Hello world",)
+        assert controller.return_value.press.call_count == 2
+
+
+def test_bad_helper_encoding_discards_outstanding_response():
+    from unittest.mock import MagicMock
+
+    transcriber = ANETranscriber(WhisperConfig(), binary_path="/fake/helper")
+    proc = MagicMock()
+    proc.poll.return_value = None
+    transcriber._server = proc
+    transcriber._model_loaded = True
+    with patch.object(
+        transcriber, "_readline_with_timeout",
+        side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+    ):
+        assert transcriber.transcribe(np.zeros(16000, dtype=np.int16), 16000) == ""
+    assert transcriber._server is None
+    assert not transcriber._model_loaded
+    proc.terminate.assert_called_once()


### PR DESCRIPTION
Finder-launched Dictate could transcribe speech but silently fail to paste when Accessibility was disabled. It also decoded the Swift helper's UTF-8 JSON using the inherited locale, causing UnicodeDecodeError for non-ASCII transcripts under an ASCII locale.

Check Accessibility before sending keyboard events, preserve the clipboard and Recent transcript, and keep an actionable failure status instead of overwriting it with Ready. Read helper responses and write logs explicitly as UTF-8; discard the helper after malformed text so a later recording cannot consume a stale response. Document the permission and manual-paste recovery path.

Validation: 1,082 tests pass, including a real subprocess emitting multilingual UTF-8 with the default pipe encoding forced to ASCII, denied-permission recovery, malformed-helper recovery, and menu status preservation. Test logging is now isolated from the user's real app logs. Actual microphone recordings were observed transcribing; end-to-end automatic paste is awaiting the Mac's Accessibility grant.
