### PR TITLE
Prepare Dictate 2.5.4 and repair Homebrew installs

### DIFF
--- a/Formula/dictate.rb
+++ b/Formula/dictate.rb
@@ -9,21 +9,28 @@ class Dictate < Formula
 
   head "https://github.com/0xbrando/dictate.git", branch: "main"
 
-  depends_on "python@3.11"
-  depends_on xcode: ["15.0", :build]
+  depends_on "python@3.12"
+  depends_on xcode: ["16.0", :build]
   depends_on arch: :arm64
+  depends_on macos: :sonoma
 
   def install
     system "swift", "build", "-c", "release", "--disable-sandbox", "--package-path", "swift-stt"
     bin.install "swift-stt/.build/release/dictate-stt"
 
-    venv = virtualenv_create(libexec, "python3.11")
-    venv.pip_install_and_link buildpath
+    virtualenv_create(libexec, "python3.12", system_site_packages: false)
+    # This third-party tap uses PyPI wheels for the ML stack. Homebrew's
+    # pip_install_and_link passes --no-deps and leaves the app unable to start.
+    system "python3.12", "-m", "pip", "--python=#{libexec}/bin/python", "install",
+           "--disable-pip-version-check", buildpath
+    bin.install_symlink libexec/"bin/dictate"
   end
 
   test do
     assert_match(/^dictate \d+\.\d+\.\d+$/, shell_output("#{bin}/dictate --version").strip)
     assert_match '"available":true', shell_output("#{bin}/dictate-stt check").delete(" ")
+    system libexec/"bin/python", "-c",
+           "import mlx.core, mlx_whisper, mlx_lm, parakeet_mlx, sounddevice, scipy, pynput, pyperclip, rumps, dotenv"
   end
 
   def caveats
@@ -31,7 +38,8 @@ class Dictate < Formula
       Dictate runs as a macOS menu bar app:
         dictate
 
-      macOS will ask for Microphone and Accessibility permissions.
+      Allow your terminal app in System Settings > Privacy & Security >
+      Microphone and Accessibility, then quit and reopen Dictate.
       The selected local models download on first use and stay cached locally.
     EOS
   end

--- a/Formula/dictate.rb
+++ b/Formula/dictate.rb
@@ -18,19 +18,26 @@ class Dictate < Formula
     system "swift", "build", "-c", "release", "--disable-sandbox", "--package-path", "swift-stt"
     bin.install "swift-stt/.build/release/dictate-stt"
 
+    (libexec/"src").install "dictate", "pyproject.toml", "README.md", "LICENSE", "LICENSES.md"
+    (bin/"dictate").write_env_script libexec/"venv/bin/dictate", {}
+  end
+
+  def post_install
+    # Install upstream wheels after Homebrew's Mach-O relocation pass. Rewriting
+    # their dylib IDs can fail (for example, tiktoken has no spare header space).
+    venv = libexec/"venv"
     python = Formula["python@3.12"].opt_bin/"python3.12"
-    virtualenv_create(libexec, python, system_site_packages: false)
+    virtualenv_create(venv, python, system_site_packages: false)
     # This third-party tap uses PyPI wheels for the ML stack. Homebrew's
     # pip_install_and_link passes --no-deps and leaves the app unable to start.
-    system python, "-m", "pip", "--python=#{libexec}/bin/python", "install",
-           "--disable-pip-version-check", buildpath
-    bin.install_symlink libexec/"bin/dictate"
+    system python, "-m", "pip", "--python=#{venv}/bin/python", "install",
+           "--disable-pip-version-check", libexec/"src"
   end
 
   test do
     assert_match(/^dictate \d+\.\d+\.\d+$/, shell_output("#{bin}/dictate --version").strip)
     assert_match '"available":true', shell_output("#{bin}/dictate-stt check").delete(" ")
-    system libexec/"bin/python", "-c",
+    system libexec/"venv/bin/python", "-c",
            "import mlx.core, mlx_whisper, mlx_lm, parakeet_mlx, sounddevice, scipy, pynput, pyperclip, rumps, dotenv"
   end
 

--- a/Formula/dictate.rb
+++ b/Formula/dictate.rb
@@ -18,10 +18,11 @@ class Dictate < Formula
     system "swift", "build", "-c", "release", "--disable-sandbox", "--package-path", "swift-stt"
     bin.install "swift-stt/.build/release/dictate-stt"
 
-    virtualenv_create(libexec, "python3.12", system_site_packages: false)
+    python = Formula["python@3.12"].opt_bin/"python3.12"
+    virtualenv_create(libexec, python, system_site_packages: false)
     # This third-party tap uses PyPI wheels for the ML stack. Homebrew's
     # pip_install_and_link passes --no-deps and leaves the app unable to start.
-    system "python3.12", "-m", "pip", "--python=#{libexec}/bin/python", "install",
+    system python, "-m", "pip", "--python=#{libexec}/bin/python", "install",
            "--disable-pip-version-check", buildpath
     bin.install_symlink libexec/"bin/dictate"
   end

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ That's it. Dictate launches in the background and appears in your menu bar. Clos
 For Qwen3-ASR support (30 languages plus 22 Chinese dialects):
 
 ```bash
-pip install dictate-mlx[qwen3-asr]
+python -m pip install --upgrade "dictate-mlx[qwen3-asr]"
 ```
 
 This is still local-only. No API key is required; the extra installs the MLX Qwen3-ASR runtime.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Dictate can use your Mac’s Neural Engine for speech recognition.
 ## Install
 
 ```bash
-pip install dictate-mlx
+python3 -m venv ~/.venvs/dictate
+source ~/.venvs/dictate/bin/activate
+python -m pip install --upgrade dictate-mlx
 dictate
 ```
 
@@ -51,7 +53,7 @@ Homebrew source install is available for users who prefer Brew. It builds the
 Swift ANE helper and installs the Python app into a Homebrew-managed virtualenv:
 
 ```bash
-brew tap 0xbrando/dictate
+brew tap 0xbrando/dictate https://github.com/0xbrando/dictate
 brew install dictate
 ```
 

--- a/dictate/__init__.py
+++ b/dictate/__init__.py
@@ -4,7 +4,7 @@ Dictate - Push-to-Talk Voice Dictation for macOS
 A local, privacy-first voice dictation menu bar app using Apple Silicon MLX models.
 """
 
-__version__ = "2.5.3"
+__version__ = "2.5.4"
 __author__ = "brando"
 
 __all__ = ["__version__"]

--- a/docs/homebrew-release.md
+++ b/docs/homebrew-release.md
@@ -1,5 +1,26 @@
 # Homebrew Release Plan
 
+## Publishing a version
+
+1. Update the version in `pyproject.toml` and `dictate/__init__.py` together.
+2. Run `python -m pytest tests/ -q`, then build with `python -m build` and
+   validate both artifacts with `python -m twine check dist/*`.
+3. Install the wheel in a fresh virtualenv, run `dictate --version` and
+   `python -m pip check`, and check imports of the transcription and menu modules.
+4. Merge the reviewed release commit. Tag that commit `vX.Y.Z`, upload the checked
+   wheel and sdist to PyPI, and attach the same artifacts to a GitHub release.
+   Keep publishing credentials outside the repository.
+5. Download the new GitHub tag archive and compute its SHA-256. Update both the
+   URL and checksum in `Formula/dictate.rb` through a follow-up PR.
+6. Refresh the tap, build the formula and run `brew test 0xbrando/dictate/dictate`.
+   Verify PyPI's published version and the tap's formula version before announcing.
+
+The short tap command assumes a separate `homebrew-dictate` repository. This
+project stores its formula in the main repository, so always include the explicit
+repository URL below. The source formula requires Xcode 16+ (Swift 6), macOS 14+
+and Apple Silicon. It resolves Python dependencies from PyPI inside an isolated
+virtualenv; it is not an offline or fully locked Homebrew-core formula.
+
 Dictate supports two possible Homebrew paths:
 
 - `Formula/dictate.rb`: source install that creates a Python virtualenv, builds
@@ -10,7 +31,7 @@ Dictate supports two possible Homebrew paths:
 ## Target User Flow
 
 ```bash
-brew tap 0xbrando/dictate
+brew tap 0xbrando/dictate https://github.com/0xbrando/dictate
 brew install dictate
 ```
 
@@ -44,7 +65,7 @@ brew install dictate
 5. Advertise:
 
    ```bash
-   brew tap 0xbrando/dictate
+   brew tap 0xbrando/dictate https://github.com/0xbrando/dictate
    brew install dictate
    ```
 
@@ -81,7 +102,7 @@ brew install dictate
 7. After the cask works locally, advertise:
 
    ```bash
-brew tap 0xbrando/dictate
+brew tap 0xbrando/dictate https://github.com/0xbrando/dictate
 brew install --cask dictate
    ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dictate-mlx"
-version = "2.5.3"
+version = "2.5.4"
 description = "Local voice-to-text accelerated by Apple Silicon. Push-to-talk dictation for macOS — 100% local, free, open source."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
PyPI is still at 2.5.0, while Homebrew points at 2.5.3 and installs the Python package without its runtime dependencies. The documented short tap command also assumes a repository that does not exist.

Prepare 2.5.4 with the merged safety and paste fixes. The Homebrew formula builds the Swift helper, then installs PyPI wheels into an isolated Python 3.12 virtualenv during post-install so Homebrew does not rewrite their native library headers. Resolve Python through its formula path, require Xcode 16+/macOS 14+, and document the explicit tap URL and release procedure. The formula URL/checksum will move to the immutable release tag in a follow-up once that tag exists.

Validation: 1,082 tests pass; wheel and sdist pass twine checks; a fresh wheel installation reports 2.5.4, passes pip check, and loads the transcription/output/menu modules. A real Homebrew source install succeeds; its command reports 2.5.4, the helper reports available, pip check passes, and every import in the formula test passes. Local dependencies are being updated to satisfy the brew test runner's version checks. The user confirmed the installed app records and pastes successfully.
